### PR TITLE
Replace hardcoded newsletter root node id

### DIFF
--- a/design/standard/templates/content/datatype/edit/cjwnewslettersubscription.tpl
+++ b/design/standard/templates/content/datatype/edit/cjwnewslettersubscription.tpl
@@ -13,7 +13,7 @@
 {/if}
 
 
-    {def $newsletter_root_node_id = 2
+    {def $newsletter_root_node_id = ezini( 'NewsletterSettings', 'RootFolderNodeId', 'cjw_newsletter.ini' )
          $available_output_formats = 2} {* settings for html table *}
 
 

--- a/design/standard/templates/newsletter/user_edit.tpl
+++ b/design/standard/templates/newsletter/user_edit.tpl
@@ -136,7 +136,7 @@
                                 {* list subscribe, remove *}
 
                                  {* fetch all available newsletter systems *}
-                                    {def $newsletter_root_node_id = 2
+                                    {def $newsletter_root_node_id = ezini( 'NewsletterSettings', 'RootFolderNodeId', 'cjw_newsletter.ini' )
                                          $newsletter_system_node_list = fetch( 'content', 'tree', hash('parent_node_id', $newsletter_root_node_id,
                                                                                             'class_filter_type', 'include',
                                                                                             'class_filter_array', array( 'cjw_newsletter_system' ),


### PR DESCRIPTION
Two template files had a hardcoded newsletter root node id set to "2", while the default config value "RootFolderNodeId" in cjw_newsletter.ini is set to "1". This patch replaces the hardcoded values with an ezIni query
