### PR TITLE
Fix page navigator missing in cjw_newsletter_list_children.tpl

### DIFF
--- a/design/admin2/templates/cjw_newsletter_list_children.tpl
+++ b/design/admin2/templates/cjw_newsletter_list_children.tpl
@@ -175,6 +175,15 @@
                  edition_node_list = $children
                  edition_node_list_count = $children_count
                  show_actions_colum = true()}
+    
+    <div class="context-toolbar subitems-context-toolbar">
+        {include  name = 'Navigator'
+                  uri = 'design:navigator/google.tpl'
+                  page_uri = $node.url_alias
+                  item_count = $children_count
+                  view_parameters = $view_parameters
+                  item_limit = $number_of_items}
+    </div>
 
         {def $viewmode_newsletter=true()}
 


### PR DESCRIPTION
The page navigator was missing in the bottom of the newsletter edition list.
With this fix it will appear the same way as in the newsletter/index page.